### PR TITLE
LIBSEARCH-16. Pass quick_search_config.yml file through ERB processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
+# QuickSearch UMD-Fork
+
+This repository is a forked version of the NSCU QuickSearch repository,
+incorporating UMD-specific changes.
+
+## Changes to NCSU QuickSearch functionality
+
+### config/quicksearch_config.yml now processed by ERB
+
+The "config/quicksearch_config.yml" file in the application created by the
+QuickSearch installation generator is passed through the ERB template processor.
+
+This enables properties in the file to be configured from environment variables.
+For example, given a "STATS_PASSWORD" environment variable, the "password"
+property in the "config/quicksearch_config.yml" file can be configured by using
+the following:
+
+```
+password: <%= ENV['STATS_PASSWORD'] %>
+```
+
 # QuickSearch
 
 > Note: This code has recently been converted to a Rails Gem Engine. It is encouraged that you use this version, but if you are

--- a/lib/quick_search/engine.rb
+++ b/lib/quick_search/engine.rb
@@ -15,7 +15,7 @@ module QuickSearch
     initializer :quick_search, :after => :add_view_paths do
       config_file = File.join(Rails.root, "/config/quick_search_config.yml")
       if File.exist?(config_file)
-        QuickSearch::Engine::APP_CONFIG = YAML.load_file(config_file)[Rails.env]
+        QuickSearch::Engine::APP_CONFIG = YAML.load(ERB.new(File.read(config_file)).result)[Rails.env]
         ActiveSupport.on_load(:action_controller) do
           # get theme / core engine classes
           theme_engine_class = "#{QuickSearch::Engine::APP_CONFIG['theme'].classify}::Engine".constantize


### PR DESCRIPTION
Modified the initialization to pass the "config/quick_search_config.yml"
file through the ERB template processor.

This enables ERB template directives to be placed in the
file, allowing specification of properties via environment variables.

https://issues.umd.edu/browse/LIBSEARCH-16