### PR TITLE
LIBSEARCH-15. Enable retrieval of loaded_link and no_results_link from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,28 @@ the following:
 password: <%= ENV['STATS_PASSWORD'] %>
 ```
 
+### loaded_link/no_results_link can be specified in searcher configuration YAML file
+
+The search configuration YAML files (typically stored in the "config/searchers"
+directory of the search application) now support "loaded_link" and
+"no_results_link" properties. These properties are intended to replace the
+"loaded_link" and "no_results_link" properties in the I18N locale files
+such as "config/locales/en.yml".
+
+Placing these properties in the YAML files allows them to be more easily
+customized on a per-server basis, through the use of server environment
+variables.
+
+The legacy behavior of using the I18N locale files such as the
+"config/locales/en.yml" file, is still supported, and, for backwards
+compatibility, takes priority over the properties in the YAML file. The use of
+I18N locale files should be considered deprecated.
+
+For cases where a "loaded_link" or "no_results_link" is specified in the locale
+file of the searcher gem, the search application can force the use of the
+properties in the YAML file by adding empty entries for the "loaded_link" and
+"no_results_link" in the I18N locale file of the search application.
+
 # QuickSearch
 
 > Note: This code has recently been converted to a Rails Gem Engine. It is encouraged that you use this version, but if you are

--- a/app/controllers/concerns/quick_search/searcher_concern.rb
+++ b/app/controllers/concerns/quick_search/searcher_concern.rb
@@ -6,7 +6,7 @@ module QuickSearch::SearcherConcern
   include QuickSearch::EncodeUtf8
   include QuickSearch::SearcherConfig
   require 'benchmark_logger'
-  require 'searcher_error'
+  require_dependency 'searcher_error'
 
   private
 

--- a/app/controllers/concerns/quick_search/searcher_concern.rb
+++ b/app/controllers/concerns/quick_search/searcher_concern.rb
@@ -6,6 +6,7 @@ module QuickSearch::SearcherConcern
   include QuickSearch::EncodeUtf8
   include QuickSearch::SearcherConfig
   require 'benchmark_logger'
+  require 'searcher_error'
 
   private
 
@@ -60,8 +61,12 @@ module QuickSearch::SearcherConcern
               instance_variable_set "@#{sm}", searcher
             rescue StandardError => e
               # logger.info e
+
+              # Wrap e in a SearcherError, so that the searcher object is
+              # available for retrieval.
+              searcher_error = QuickSearch::SearcherError.new(e, searcher)
               logger.info "FAILED SEARCH: #{sm} | #{params_q_scrubbed}"
-              instance_variable_set :"@#{sm.to_s}", e
+              instance_variable_set :"@#{sm.to_s}", searcher_error
             end
           end
         end

--- a/app/searchers/quick_search/searcher.rb
+++ b/app/searchers/quick_search/searcher.rb
@@ -25,6 +25,28 @@ module QuickSearch
       raise #FIXME: pick some good error
     end
 
+    # Returns a String representing the link to use when no results are
+    # found for a search.
+    #
+    # This default implementation first looks for the "i18n_key" and
+    # "default_i18n_key" in the I18N locale files. If no entry is found
+    # the "no_results_link" from the searcher configuration is returned.
+    #
+    # Using the I18N locale files is considered legacy behavior (but
+    # is preferred in this method to preserve existing functionality).
+    # Use of the searcher configuration file is preferred.
+    def no_results_link(service_name, i18n_key, default_i18n_key = nil)
+      locale_result = I18n.t(i18n_key, default: I18n.t(default_i18n_key))
+      return locale_result if locale_result
+
+      begin
+        config_class = "QuickSearch::Engine::#{service_name.upcase}_CONFIG".constantize
+        config_class['no_results_link']
+      rescue NameError
+        nil
+      end
+    end
+
     private
 
     def http_request_queries

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -18,7 +18,7 @@
         <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging',  module_link: module_link } %>
     <% elsif searcher.results.blank? %>
         <h2 class="result-set-heading"><%= module_display_name %></h2>
-        <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name} %>
+        <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name, searcher: searcher} %>
     <% else %>
         <% total = number_with_delimiter(searcher.total) %>
         <% unless defined? searcher.loaded_link_mobile %>

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -1,12 +1,21 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" >
     <% if searcher.is_a? StandardError %>
+
+        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
+            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
+            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
+        <% elsif searcher.is_a? QuickSearch::SearcherError %>
+            <% searcher_obj = searcher.searcher %>
+            <% module_link = searcher_obj.loaded_link %>
+        <% end %>
+
         <h2 class="result-set-heading"><%= module_display_name %></h2>
         <% if params[:page].blank? %>
             <% page = 1 %>
         <% else %>
             <% page = params[:page] %>
         <% end %>
-        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging' } %>
+        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging',  module_link: module_link } %>
     <% elsif searcher.results.blank? %>
         <h2 class="result-set-heading"><%= module_display_name %></h2>
         <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name} %>

--- a/app/views/quick_search/search/_module_with_paging.html.erb
+++ b/app/views/quick_search/search/_module_with_paging.html.erb
@@ -11,7 +11,7 @@
 
         <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging', module_link: module_link } %>
     <% elsif searcher.results.blank? %>
-        <%= render partial: '/quick_search/search/no_results', locals: { :service_name => service_name } %>
+        <%= render partial: '/quick_search/search/no_results', locals: { :service_name => service_name, searcher: searcher } %>
     <% else %>
         <% total = number_with_delimiter(searcher.total) %>
         <p>Page <%= page %> of <%= total %> <%= t("#{service_name}_search.short_display_name")  %> results</p>

--- a/app/views/quick_search/search/_module_with_paging.html.erb
+++ b/app/views/quick_search/search/_module_with_paging.html.erb
@@ -1,6 +1,15 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" data-turbolinks="false">
     <% if searcher.is_a? StandardError %>
-        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging' } %>
+
+        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
+            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
+            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
+        <% elsif searcher.is_a? QuickSearch::SearcherError %>
+            <% searcher_obj = searcher.searcher %>
+            <% module_link = searcher_obj.loaded_link %>
+        <% end %>
+
+        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging', module_link: module_link } %>
     <% elsif searcher.results.blank? %>
         <%= render partial: '/quick_search/search/no_results', locals: { :service_name => service_name } %>
     <% else %>

--- a/app/views/quick_search/search/_no_results.html.erb
+++ b/app/views/quick_search/search/_no_results.html.erb
@@ -1,11 +1,11 @@
 <p class='search-error-message'><i class="fa fa-info-circle"></i> No <%= t("#{service_name}_search.short_display_name") %> results found for <span class="query"><%= display_query %></span></p>
 <p class="see-all-results show-for-medium-up">
-    <%= link_to t("#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
+    <%= link_to searcher.no_results_link(service_name, "#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
         <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.no_results_service_message") %>
     <% end %>
 </p>
 <p class="see-all-results show-for-small-only">
-    <%= link_to t("#{service_name}_search.no_results_link_mobile", :default => t("#{service_name}_search.no_results_link")), data: {"quicksearch_ga_action" => "no-results"} do %>
+    <%= link_to searcher.no_results_link(service_name, "#{service_name}_search.no_results_link_mobile", "#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
         <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.no_results_service_message") %>
     <% end %>
 </p>

--- a/app/views/quick_search/search/_search_error.html.erb
+++ b/app/views/quick_search/search/_search_error.html.erb
@@ -1,9 +1,9 @@
-<p class="search-error" data-quicksearch-search-endpoint="<%= service_name %>" 
+<p class="search-error" data-quicksearch-search-endpoint="<%= service_name %>"
     data-quicksearch-page="<%= page %>"
     data-quicksearch-template="<%= template %>"></p>
 <p class="search-error-rescue search-error-message"><i class="fa fa-warning"></i> We're sorry. This search took too long.</p>
 <p class="search-error-rescue see-all-results">
-    <%= link_to t("#{service_name}_search.loaded_link") + url_encode("#{@query}"), data: {"quicksearch_ga_action" => "error"} do %>
+    <%= link_to module_link, data: {"quicksearch_ga_action" => "error"} do %>
     <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.error_service_message") %> for <span class='query'>"<%= truncate(@query, length: 100, separator: ' ') %>"</span>
     <% end %>
 </p>

--- a/lib/searcher_error.rb
+++ b/lib/searcher_error.rb
@@ -1,0 +1,12 @@
+# StandardError wrapper that enables the affected searcher to be specified
+module QuickSearch
+  class SearcherError < StandardError
+    attr_reader :searcher
+
+    def initialize(e=nil, searcher)
+      super e
+      @searcher = searcher
+      set_backtrace e.backtrace if e
+    end
+  end
+end


### PR DESCRIPTION
Enable the "loaded_link" and "no_results_link" properties to be specified in the searcher configuration YAML file, instead of in the I18N locale file (en.yml).

The legacy behavior of using the I18N locale file is preserved, and any entries in the I18N locale file override the properties in the YAML file.

https://issues.umd.edu/browse/LIBSEARCH-15