### PR TITLE
LIBSEARCH-128. Removed "primary_searcher_config" variable

### DIFF
--- a/app/controllers/concerns/quick_search/searcher_concern.rb
+++ b/app/controllers/concerns/quick_search/searcher_concern.rb
@@ -15,8 +15,6 @@ module QuickSearch::SearcherConcern
       search_threads = []
       @found_types = [] # add the types that are found to a navigation bar
 
-      primary_searcher_config = ''
-
       if primary_searcher == 'defaults'
         searchers = QuickSearch::Engine::APP_CONFIG['searchers']
       else
@@ -45,8 +43,8 @@ module QuickSearch::SearcherConcern
               # FIXME: Probably want to set paging and offset somewhere else.
               # searcher = klass.new(http_client, params_q_scrubbed, QuickSearch::Engine::APP_CONFIG['per_page'], 0, 1, on_campus?(request.remote_ip))
               if sm == primary_searcher
-                if primary_searcher_config.has_key? 'with_paging'
-                  per_page = primary_searcher_config['with_paging']['per_page']
+                if searcher_config.has_key? 'with_paging'
+                  per_page = searcher_config['with_paging']['per_page']
                 else
                   per_page = 10
                 end


### PR DESCRIPTION
Removed "primary_searcher_config" variable as it is causing all
single searcher HTTP searches to immediately fail, due to an attempt
to treat a String as a Hash.

Replaced usages of the "primary_searcher_config" variable with the
"searcher_config" variable.

This prevent a downstream error when using searchers that use a
"loaded_link" method.

https://issues.umd.edu/browse/LIBSEARCH-128