### PR TITLE
LIBSEARCH-127. Fixed QuickSearch single searcher search page display

### DIFF
--- a/app/controllers/quick_search/search_controller.rb
+++ b/app/controllers/quick_search/search_controller.rb
@@ -30,7 +30,12 @@ module QuickSearch
         additional_services = []
       end
       loaded_searches(additional_services)
-      @common_searches = searcher_cfg['common_searches'] || []
+
+      @common_searches = []
+      if searcher_cfg and searcher_cfg.has_key? 'common_searches'
+        @common_searches = searcher_cfg['common_searches']
+      end
+
       #TODO: maybe a default template for single-searcher searches?
       http_search(searcher_name, "quick_search/search/#{searcher_name}_search")
     end


### PR DESCRIPTION
Fixed an issue where the single searcher search page displays an error
for searchers without an explicit "config/<searcher>_config.yml"
configuration file.

The cause of the error not handling the possibility that the
"search_cfg" variable may be nil. This is likely just an oversight,
as a nil check is performed in other places in the method.

Modified the code to provide "@common_searches" with a default value,
which can then be overwritten if the "search_cfg" variable contains
the "common_searches" key.

https://issues.umd.edu/browse/LIBSEARCH-127