### PR TITLE
LIBSEARCH-136. Added "module_link" to JSON REST endpoint response

### DIFF
--- a/README-UMD.md
+++ b/README-UMD.md
@@ -7,6 +7,12 @@ incorporating UMD-specific changes.
 
 ### Best Bets do not fade out
 
-Modified the "app/assets/javascripts/quick_search/quicksearch.js" file so that
+Modified "app/assets/javascripts/quick_search/quicksearch.js" so that
 the Best Bets label remains displayed, instead of fading out after a few
 seconds.
+
+### Native search interface link is included in JSON results
+
+Modified "app/controllers/quick_search/search_controller.rb" so that
+the link to the native search interface, including query parameters, is
+included in the JSON result.

--- a/app/controllers/quick_search/search_controller.rb
+++ b/app/controllers/quick_search/search_controller.rb
@@ -107,10 +107,17 @@ module QuickSearch
               result_list << result.to_h
             end
 
+            if searcher.is_a? StandardError
+              module_link = QuickSearch::Searcher.module_link_on_error(service, searcher, @query)
+            else
+              module_link = searcher.loaded_link
+            end
+
             render :json => { :endpoint => endpoint,
                               :per_page => @per_page.to_s,
                               :page => @page.to_s,
                               :total => searcher.total,
+                              :module_link => module_link,
                               :results => result_list
             }
           }


### PR DESCRIPTION
Added "module_link" to JSON REST endpoint response so that it is
available for use as the "native interface" link in the Hippo GUI.

https://issues.umd.edu/browse/LIBSEARCH-136