### PR TITLE
LIBSEARCH-144. Include query and no_results_link in json results.

### DIFF
--- a/README-UMD.md
+++ b/README-UMD.md
@@ -16,3 +16,8 @@ seconds.
 Modified "app/controllers/quick_search/search_controller.rb" so that
 the link to the native search interface, including query parameters, is
 included in the JSON result.
+
+### No results link is included in JSON results
+
+Modified "app/controllers/quick_search/search_controller.rb" so that
+the "no_results_link" for the searcher is included in the JSON result.

--- a/app/controllers/quick_search/search_controller.rb
+++ b/app/controllers/quick_search/search_controller.rb
@@ -106,18 +106,21 @@ module QuickSearch
             searcher.results.each do |result|
               result_list << result.to_h
             end
+            no_results_link = searcher.no_results_link(endpoint, nil)
 
             if searcher.is_a? StandardError
-              module_link = QuickSearch::Searcher.module_link_on_error(service, searcher, @query)
+              module_link = QuickSearch::Searcher.module_link_on_error(endpoint, searcher, @query)
             else
               module_link = searcher.loaded_link
             end
 
             render :json => { :endpoint => endpoint,
+                              :query => @query,
                               :per_page => @per_page.to_s,
                               :page => @page.to_s,
                               :total => searcher.total,
                               :module_link => module_link,
+                              :no_results_link => no_results_link,
                               :results => result_list
             }
           }


### PR DESCRIPTION
Also, fixed the module_link to use 'endpoint' since variable 'service' is out of scope.

https://issues.umd.edu/browse/LIBSEARCH-144