### PR TITLE
LIBSEARCH-155. Pass Best Bet keywords through "filter_query" method

### DIFF
--- a/README-UMD.md
+++ b/README-UMD.md
@@ -21,3 +21,16 @@ included in the JSON result.
 
 Modified "app/controllers/quick_search/search_controller.rb" so that
 the "no_results_link" for the searcher is included in the JSON result.
+
+### Best Bet keywords are passed through "filter_query" method
+
+Query terms entered by the user are passed through the the "filter_query" method
+in "app/controllers/concerns/quick_search/query_filter.rb". This modifies the
+query term, such as replacing dashes with whitespace.
+
+This is an issue when attempting to match against the Best Bet keywords, as
+a keyword with a dash ("-') will never be found. To ensure that such a keyword
+will be found, the Best Bet initializer in "lib/quick_search/engine.rb" file has
+been modified to pass the keywords through the "filter_query" method. This
+ensures that the same textual changes that occur to the query terms are also
+applied to the Best Bet keywords.

--- a/lib/quick_search/engine.rb
+++ b/lib/quick_search/engine.rb
@@ -11,7 +11,7 @@ module QuickSearch
     #
     # This way, we can make application specific overrides of views, otherwise fall back to theme,
     # and finally fall back to the QS core if needed.
-    
+
     initializer :quick_search, :after => :add_view_paths do
       config_file = File.join(Rails.root, "/config/quick_search_config.yml")
       if File.exist?(config_file)
@@ -44,12 +44,28 @@ module QuickSearch
     initializer :best_bets, :after => :quick_search do
       if defined? QuickSearch::Engine::APP_CONFIG and QuickSearch::Engine::APP_CONFIG['best_bets']['solr_url'].empty?
         best_bets_file = File.join(Rails.root, "/config/best_bets.yml")
+
         if File.exist?(best_bets_file)
+
+          # Helper class for enabling access to the "filter_query" method
+          # in QuickSearch::QueryFilter concern
+          class BestBetFilter
+            include QuickSearch::QueryFilter
+
+            def filter(keyword)
+              filter_query(keyword)
+            end
+          end
+
+          best_bet_filter = BestBetFilter.new
           QuickSearch::Engine::BEST_BETS = YAML.load_file(best_bets_file)['best_bets']
           QuickSearch::Engine::BEST_BETS_INDEX = {}
           QuickSearch::Engine::BEST_BETS.each do |best_bet_name, best_bet|
             QuickSearch::Engine::BEST_BETS[best_bet_name]['id'] = best_bet_name
             best_bet['keywords'].each do |keyword|
+              # Pass keyword through "filter_query" method so that keyword
+              # will match query term passed through the same method
+              keyword = best_bet_filter.filter(keyword)
               QuickSearch::Engine::BEST_BETS_INDEX[keyword.downcase] = best_bet_name
             end
           end

--- a/test/dummy/config/best_bets.yml
+++ b/test/dummy/config/best_bets.yml
@@ -84,3 +84,9 @@ best_bets:
     keywords:
     - pubmed
     - pub med
+  testbestbet:
+    title: Test Best Bet Entry
+    description: This is a test Best Bet entry
+    url: http://example.org
+    keywords:
+    - 123-456

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   mount QuickSearch::Engine => "/"
 
   root :to => 'quick_search/search#index'
+  get 'xhr_search' => 'quick_search/search#xhr_search', :defaults => { :format => 'html' }
 end

--- a/test/integration/best_bets_initializer_test.rb
+++ b/test/integration/best_bets_initializer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class BestBestInitializerTest < ActionDispatch::IntegrationTest
+  test 'best bet keyword with dash should be found' do
+    # Clear the solr_url so we don't try to get Best Bet from Solr
+    QuickSearch::Engine::APP_CONFIG['best_bets']['solr_url'] = ''
+
+    # Keyword for "testbestbet" entry in test/dummy/config/best_bets.yml
+    visit xhr_search_path(q: '123-456', endpoint: 'best_bets', format: 'json')
+
+    json = JSON.parse(page.html)
+    first_result = json['results'][0]
+    assert_equal 'testbestbet', first_result['id']
+  end
+end


### PR DESCRIPTION
When loading the Best Bet keywords, pass them through the "filter_query"
method in the "QuickSearch::QueryFilter" concern, so that they will be
matched with a query term passed  through the same method. This takes
care of things like a dash (hyphen) being removed from the query term.

The implementation was somewhat complicated by the fact that the
"filter_query" method is a private method on a Rails Concern. This was
handled by creating a helper class in the initializer that delegates to
the concern. It is not clear if this is the best way to accomplish this,
but it does appear to work.

https://issues.umd.edu/browse/LIBSEARCH-155